### PR TITLE
Add interactive theme switcher

### DIFF
--- a/pushtest.html
+++ b/pushtest.html
@@ -10,6 +10,7 @@
 </head>
 <body>
   <canvas id="stars"></canvas>
+  <div id="theme-toggle" title="Switch theme"><div class="toggle-icon"></div></div>
 
   <div class="container">
     <img src="/ethancloud-logo.png" alt="EthanCloud Logo" class="logo" />

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@
     const ctx = c.getContext("2d");
     c.width = window.innerWidth;
     c.height = window.innerHeight;
+    let starColor = "#fff";
+    let glowColor = "#00d4ff";
     let stars = [];
     for (let i = 0; i < 200; i++) {
       stars.push({ x: Math.random() * c.width, y: Math.random() * c.height, r: Math.random() * 1.5 });
@@ -14,9 +16,9 @@
     });
     function draw() {
       ctx.clearRect(0, 0, c.width, c.height);
-      ctx.fillStyle = "#fff";
+      ctx.fillStyle = starColor;
       ctx.shadowBlur = 5;
-      ctx.shadowColor = "#00d4ff";
+      ctx.shadowColor = glowColor;
       for (let i = 0; i < stars.length; i++) {
         let s = stars[i];
         let dx = (mouse.x - c.width / 2) * 0.01;
@@ -60,6 +62,17 @@
     window.onload = function() {
       const tagline = document.getElementById('tagline');
       typeEffect(tagline, 75);
+      document.getElementById('theme-toggle').addEventListener('click', function() {
+        document.getElementById('theme-toggle').classList.toggle('active');
+        document.body.classList.toggle('blackhole');
+        if (document.body.classList.contains('blackhole')) {
+          starColor = '#a020f0';
+          glowColor = '#a020f0';
+        } else {
+          starColor = '#fff';
+          glowColor = '#00d4ff';
+        }
+      });
     }
 
     // Terminal logic

--- a/style.css
+++ b/style.css
@@ -5,6 +5,12 @@
       font-family: 'Fira Code', monospace;
       overflow: hidden;
       position: relative;
+      transition: background 0.5s, color 0.5s;
+    }
+
+    body.blackhole {
+      background: radial-gradient(circle at center, #000, #050505 60%, #000 100%);
+      color: #e0e0e0;
     }
 
     /* Scanline overlay */
@@ -23,10 +29,65 @@
       z-index: 999;
     }
 
+    body.blackhole::before {
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(160, 32, 240, 0.05),
+        rgba(160, 32, 240, 0.05) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+    }
+
     #stars {
       position: fixed;
       top: 0; left: 0; width: 100%; height: 100%;
       z-index: -1;
+    }
+
+    #theme-toggle {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: #00d4ff;
+      box-shadow: 0 0 15px #00d4ffaa;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.5s, box-shadow 0.5s;
+      z-index: 1001;
+    }
+
+    #theme-toggle:hover {
+      transform: rotate(180deg) scale(1.1);
+      box-shadow: 0 0 25px #ff00ff;
+    }
+
+    #theme-toggle .toggle-icon {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: radial-gradient(circle at center, #fff, #00d4ff);
+      transition: background 0.5s, transform 1s;
+    }
+
+    #theme-toggle.active .toggle-icon {
+      animation: spin 1s linear;
+      background: radial-gradient(circle at center, #a020f0, #ff1493);
+    }
+
+    body.blackhole #theme-toggle {
+      background: #a020f0;
+      box-shadow: 0 0 15px #a020f0aa;
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
     }
 
     .container {
@@ -75,6 +136,13 @@
       position: relative;
     }
 
+    body.blackhole .links a {
+      border-color: #a020f0;
+      color: #a020f0;
+      background: rgba(160, 32, 240, 0.07);
+      box-shadow: 0 0 15px #a020f055, 0 0 30px #a020f033;
+    }
+
     .links a:hover {
       background: linear-gradient(45deg, #00d4ff, #ff00ff, #00ffae, #00d4ff);
       background-size: 400% 400%;
@@ -82,6 +150,12 @@
       animation: rainbow 3s ease infinite;
       transform: scale(1.05);
       box-shadow: 0 0 20px #00d4ff, 0 0 50px #00d4ff99;
+    }
+
+    body.blackhole .links a:hover {
+      background: linear-gradient(45deg, #a020f0, #ff1493, #8a2be2, #a020f0);
+      box-shadow: 0 0 20px #a020f0, 0 0 50px #a020f099;
+      color: #fff;
     }
 
     @keyframes rainbow {


### PR DESCRIPTION
## Summary
- implement a circular theme toggle widget
- add black hole theme styles
- update starfield colors when switching theme
- hook theme toggle into page load

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68756a2b92408333bf08f5e0be8ea656